### PR TITLE
Fix stuttering zoom caused by suppressed scale writes

### DIFF
--- a/src/zoominator-controller.cpp
+++ b/src/zoominator-controller.cpp
@@ -91,6 +91,14 @@ static inline bool nearly_equal_vec2(const vec2 &a, const vec2 &b, float eps = 0
 	return nearly_equal(a.x, b.x, eps) && nearly_equal(a.y, b.y, eps);
 }
 
+/* Write-suppression threshold for scale. Position is in pixels, where the 0.01
+ * default is a sane "nothing changed" epsilon, but scale is a ratio: 0.01 there
+ * is 1% of the source, i.e. tens of pixels of rendered size. Sharing the pixel
+ * epsilon made a slow zoom accumulate scale silently for several frames and
+ * then apply it in one step, while position kept updating every frame. Small
+ * enough here that even an 8K source stays under a hundredth of a pixel. */
+static constexpr float kScaleEpsilon = 1.0e-5f;
+
 static inline void logi(bool enabled, const char *fmt, ...)
 {
 	if (!enabled)
@@ -2485,7 +2493,7 @@ void ZoominatorController::applyZoomToScene(double t)
 		pos.x = (float)((double)anchorX + ((double)state.orig.effectivePos.x - (double)fx) * z + offsetX);
 		pos.y = (float)((double)anchorY + ((double)state.orig.effectivePos.y - (double)fy) * z + offsetY);
 
-		if (!state.lastAppliedValid || !nearly_equal_vec2(state.lastAppliedScale, sc)) {
+		if (!state.lastAppliedValid || !nearly_equal_vec2(state.lastAppliedScale, sc, kScaleEpsilon)) {
 			obs_sceneitem_set_scale(state.item, &sc);
 			state.lastAppliedScale = sc;
 		}


### PR DESCRIPTION
## Problem

Zooms stutter, and the stutter gets worse the **slower** the zoom. The reporter narrowed it down empirically before the cause was known: a zoom looks smooth while `zoomFactor` is large relative to the animation duration in seconds, and visibly jerky otherwise. Zoom factor 1.25 over 1000 ms is passable; the same factor over 1800 ms is not.

That "slower is worse" shape is the giveaway - it points at a write-suppression threshold rather than anything timing related.

## Cause

`applyZoomToScene()` avoids redundant writes by comparing the value it is about to set against the last one it applied:

```cpp
if (!state.lastAppliedValid || !nearly_equal_vec2(state.lastAppliedScale, sc)) { ... }
if (!state.lastAppliedValid || !nearly_equal_vec2(state.lastAppliedPos, pos))  { ... }
```

Both use `nearly_equal_vec2`'s default epsilon of `0.01`. For **position** that means 0.01 px, a reasonable "nothing changed" threshold. For **scale** it is 0.01 of a *ratio* - 1% of the source. On a 1080x1920 item that is 10.8 x 19.2 pixels of rendered size.

So scale writes are suppressed for as long as the accumulated change stays under 1%, then applied in a single step, while position keeps updating every frame. The anchor glides and the size lurches.

Walking a 60 fps animation shows how much is dropped:

```
zoom 1.25 over 1800 ms:  86 of 108 scale writes suppressed
zoom 2.00 over 1000 ms:  10 of  60 scale writes suppressed
```

Twenty-two size updates across 1.8 seconds of animation.

Scale updates every frame only while the per-frame delta clears the epsilon, i.e. while `(zoomFactor - 1) >= 0.4 * seconds`. For 1.25 that is 0.63 s and for 2.0 it is 2.5 s, which is exactly the boundary the reporter found by hand.

## Fix

Give scale its own epsilon, small enough that even an 8K source stays under a hundredth of a pixel of rendered change. Position keeps the pixel epsilon it wants.

One line plus a comment explaining the unit mismatch, so the two thresholds do not get merged again.

## Verification

Built clean (MSVC 19.44, Release x64, 0 warnings). Confirmed in OBS 32.2.1: the reporter's worst-case settings (zoom 1.25, 1800 ms in/out) went from reliably jerky to smooth, with Follow Mouse both on and off.

This one is independent of the other changes I am opening and applies to rotated and unrotated sources alike - any sufficiently slow zoom hits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
