### PR TITLE
Fix zoom framing for rotated scene items

### DIFF
--- a/src/zoominator-controller.cpp
+++ b/src/zoominator-controller.cpp
@@ -91,6 +91,22 @@ static inline bool nearly_equal_vec2(const vec2 &a, const vec2 &b, float eps = 0
 	return nearly_equal(a.x, b.x, eps) && nearly_equal(a.y, b.y, eps);
 }
 
+/* Scene-item rotation, in the same sense libobs applies it (about +Z, degrees):
+ *   x' = x*cos - y*sin
+ *   y' = x*sin + y*cos
+ */
+static inline void rotation_sin_cos(float degrees, float &sinOut, float &cosOut)
+{
+	if (degrees == 0.0f) {
+		sinOut = 0.0f;
+		cosOut = 1.0f;
+		return;
+	}
+	const double rad = (double)degrees * 3.14159265358979323846 / 180.0;
+	sinOut = (float)std::sin(rad);
+	cosOut = (float)std::cos(rad);
+}
+
 static inline void logi(bool enabled, const char *fmt, ...)
 {
 	if (!enabled)
@@ -2206,16 +2222,31 @@ void ZoominatorController::captureOriginal(obs_sceneitem_t *item)
 		orig.effectiveScale.y = renderedH / visibleH;
 	}
 
-	orig.effectivePos = orig.pos;
+	/* libobs maps a scene item as
+	 *     p_scene = R(rot) * (S * p_local - origin) + pos
+	 * (update_item_transform, obs-scene.c), where origin is the alignment
+	 * offset inside the scaled item. The zoom re-anchors every item to
+	 * top-left alignment but deliberately leaves rot untouched, so the
+	 * alignment origin must be rotated before it is subtracted. Subtracting it
+	 * unrotated anchors a rotated source as if it were axis-aligned, which
+	 * swings it off the canvas. Reduces to the old expression when rot == 0. */
+	vec2 originOffset{};
 	if (orig.align & OBS_ALIGN_RIGHT)
-		orig.effectivePos.x -= renderedW;
+		originOffset.x = renderedW;
 	else if (!(orig.align & OBS_ALIGN_LEFT))
-		orig.effectivePos.x -= renderedW * 0.5f;
+		originOffset.x = renderedW * 0.5f;
 
 	if (orig.align & OBS_ALIGN_BOTTOM)
-		orig.effectivePos.y -= renderedH;
+		originOffset.y = renderedH;
 	else if (!(orig.align & OBS_ALIGN_TOP))
-		orig.effectivePos.y -= renderedH * 0.5f;
+		originOffset.y = renderedH * 0.5f;
+
+	float originSin = 0.0f;
+	float originCos = 1.0f;
+	rotation_sin_cos(orig.rot, originSin, originCos);
+
+	orig.effectivePos.x = orig.pos.x - (originOffset.x * originCos - originOffset.y * originSin);
+	orig.effectivePos.y = orig.pos.y - (originOffset.x * originSin + originOffset.y * originCos);
 
 	orig.valid = true;
 
@@ -2242,6 +2273,11 @@ void ZoominatorController::captureOriginalSceneItems(const std::vector<obs_scene
 	for (const auto &state : sceneItems) {
 		if (!state.item || !state.orig.valid)
 			continue;
+		/* Hidden items are still transformed (so they stay consistent if they
+		 * are switched on mid-zoom) but must not drive the framing bounds:
+		 * they show nothing, and scenes routinely park them far off-canvas. */
+		if (!obs_sceneitem_visible(state.item))
+			continue;
 		obs_source_t *src = obs_sceneitem_get_source(state.item);
 		if (!src)
 			continue;
@@ -2249,10 +2285,35 @@ void ZoominatorController::captureOriginalSceneItems(const std::vector<obs_scene
 		const float sh = (float)obs_source_get_height(src);
 		const float visibleW = std::max(1.0f, sw - (float)state.orig.crop.left - (float)state.orig.crop.right);
 		const float visibleH = std::max(1.0f, sh - (float)state.orig.crop.top - (float)state.orig.crop.bottom);
-		const float minX = state.orig.effectivePos.x;
-		const float minY = state.orig.effectivePos.y;
-		const float maxX = minX + visibleW * state.orig.effectiveScale.x;
-		const float maxY = minY + visibleH * state.orig.effectiveScale.y;
+		const float renderedW = visibleW * state.orig.effectiveScale.x;
+		const float renderedH = visibleH * state.orig.effectiveScale.y;
+
+		/* Axis-aligned bounds of the item as it actually appears, i.e. of the
+		 * rotated quad anchored at effectivePos. Treating a rotated item as an
+		 * upright renderedW x renderedH box puts these bounds somewhere the
+		 * source is not, and the framing clamp below then pushes the real
+		 * source off-canvas by exactly that error. */
+		float boundsSin = 0.0f;
+		float boundsCos = 1.0f;
+		rotation_sin_cos(state.orig.rot, boundsSin, boundsCos);
+
+		const float cornerX[4] = {0.0f, renderedW, 0.0f, renderedW};
+		const float cornerY[4] = {0.0f, 0.0f, renderedH, renderedH};
+
+		float minX = state.orig.effectivePos.x;
+		float minY = state.orig.effectivePos.y;
+		float maxX = minX;
+		float maxY = minY;
+		for (int corner = 0; corner < 4; ++corner) {
+			const float px =
+				state.orig.effectivePos.x + cornerX[corner] * boundsCos - cornerY[corner] * boundsSin;
+			const float py =
+				state.orig.effectivePos.y + cornerX[corner] * boundsSin + cornerY[corner] * boundsCos;
+			minX = std::min(minX, px);
+			maxX = std::max(maxX, px);
+			minY = std::min(minY, py);
+			maxY = std::max(maxY, py);
+		}
 
 		if (!sceneContentBoundsValid) {
 			sceneContentMin.x = minX;


### PR DESCRIPTION
## Problem

Zooming a **rotated** scene item moves it completely off-canvas for the whole duration of the zoom, snapping back only once the de-zoom animation finishes.

Reproduces reliably with a portrait source on a landscape canvas - a 1080x1920 video rotated -90 degrees on a 1920x1080 canvas (OBS 32.2.1, Windows):

1. Add the source, rotate it -90, position it to fill the canvas.
2. Tick it under **Sources**, set a zoom trigger, press it.
3. The source vanishes off-canvas. The zoom itself is clearly still running - the outline grows at the configured rate - and it returns to its original position once the animation completes.

## Cause

libobs maps a scene item as

```
p_scene = R(rot) * (S * p_local - origin) + pos
```

(`update_item_transform`, `libobs/obs-scene.c`), where `origin` is the alignment offset within the scaled item.

`captureOriginal()` builds its geometry as if `rot` were always `0`. It reads `rot` and restores it faithfully, but never uses it in a calculation, so both derived quantities are wrong for a rotated item:

**1. `effectivePos` subtracts the alignment origin unrotated.** The zoom re-anchors every item to top-left alignment but deliberately leaves `rot` untouched, so that origin has to be rotated before it is removed. Subtracting it unrotated anchors a rotated item as if it were axis-aligned.

**2. The content bounds treat the item as an upright `renderedW x renderedH` box.** For the source above:

|   | computed by `captureOriginalSceneItems()` | actually on screen |
|---|---|---|
| x | 0 -> 1080 | 0 -> 1920 |
| y | **1080 -> 3000** | 0 -> 1080 |

The computed box is a tall strip entirely *below* a 1080-high canvas. The framing clamp in `applyTransform()` then correctly compensates for that phantom box, displacing the real source by exactly that error. At zoom factor 1.25 the item lands at `y[-1350..0]` - no visible overlap with the canvas at all.

This also explains the secondary symptoms: the animation looks right because `set_scale` was never wrong, and the item returns to normal because `restoreOriginal()` writes back the saved transform verbatim.

## Fix

- Rotate the alignment origin before subtracting it: `pivot = pos - R(rot) * origin`.
- Compute the content bounds as the axis-aligned bounds of the **rotated** quad.

Both reduce algebraically to the previous expressions when `rot == 0`, so unrotated scenes are unaffected.

Additionally, hidden items no longer contribute to the content bounds. They render nothing, and scenes routinely park them far off-canvas, where they stretch the framing region for no visible benefit. They are still transformed, so they stay consistent if switched on mid-zoom.

## Verification

Built clean (MSVC 19.44, Release x64, 0 warnings) and confirmed fixed in OBS 32.2.1 against the reporting scene.

The geometry was also replayed offline through both the old and new models using that scene's real transform values:

```
old model  -> x[285..2685] y[-1350..0]     (reproduces the bug)
new model  -> x[-240..2160] y[-135..1215]  (covers the canvas)
no behaviour change when rot == 0          ok
rot 270 matches rot -90                    ok
```

I kept that harness out of the diff since the project carries no test infrastructure and `.gitignore` whitelists top-level paths. Happy to add it under `tests/` if you would like it in the tree.

## Note on an unrelated observation

While tracing this I noticed `portrait_cover` is read in `loadSettings()` and written in `saveSettings()` but never used anywhere else, so the "Portrait cover, auto-scale to fill vertical canvases" checkbox currently has no effect. Not touched here - flagging it in case it is an oversight rather than a stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
