### PR TITLE
Ignore the cursor entirely when Follow Mouse is disabled

### DIFF
--- a/src/zoominator-controller.cpp
+++ b/src/zoominator-controller.cpp
@@ -2388,7 +2388,16 @@ void ZoominatorController::applyZoomToScene(double t)
 		}
 	} else {
 		if (!targetHasPos) {
-			if (followHasPos) {
+			if (!followMouse) {
+				/* Follow Mouse is off in settings, so the cursor should not
+				 * influence the zoom at all - not even by seeding the focal
+				 * point at trigger time. Zoom about the canvas centre.
+				 * The runtime toggle is deliberately left alone below: that
+				 * path freezes the zoom where the cursor last led it, which
+				 * is the point of toggling mid-zoom. */
+				targetX = (float)centerX;
+				targetY = (float)centerY;
+			} else if (followHasPos) {
 				targetX = followX;
 				targetY = followY;
 			} else if (mapped) {


### PR DESCRIPTION
## Problem

With **Follow Mouse** unticked, the zoom still centres on wherever the pointer happened to be when the trigger fired, and then stops tracking once the animation ends. From the user's side the setting looks half-applied: the cursor clearly influenced the zoom, but the source does not follow.

## Cause

In `applyZoomToScene()`, the non-follow branch latches the focal point once per zoom:

```cpp
} else {
    if (!targetHasPos) {
        if (followHasPos)      { targetX = followX; targetY = followY; }
        else if (mapped)       { targetX = mx; targetY = my; }   // <- the cursor
        ...
```

There are two different ways to reach that branch and they currently share one behaviour:

1. **Follow Mouse is off in settings** - the user has asked for the cursor not to matter.
2. **Follow Mouse was switched off at runtime** via the toggle hotkey, mid-zoom - here freezing wherever the cursor last led the zoom is exactly right, and `toggleFollowMouseRuntime()` deliberately seeds `targetX/targetY` from `followX/followY` for that purpose.

Case 2 is intentional. Case 1 falls through to the same code and picks up the pointer position.

## Fix

Distinguish them. When `followMouse` is off in settings, focus the canvas centre and ignore the pointer entirely. The runtime-toggle path is untouched.

## Verification

Built clean (MSVC 19.44, Release x64, 0 warnings) and confirmed in OBS 32.2.1. Instrumented across 159 animation ticks with Follow Mouse off, while the cursor moved from (928, 402) to (861, 670):

```
f=(960.00,540.00)     <- every tick, zero variation
```

## Worth saying explicitly

This is a **behaviour change**, not purely a defect fix, and it is the one change in this set where you may reasonably disagree. If zoom-to-wherever-the-cursor-was is intended behaviour for the non-follow case, then the fix belongs in the UI wording rather than here, or behind a separate option. Happy to close this or rework it as a setting - it is separated from my other PRs precisely so it can be judged on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
